### PR TITLE
Changement Appelation Leaderboard

### DIFF
--- a/class/header.php
+++ b/class/header.php
@@ -78,11 +78,8 @@ class Header
             </a>
                 <ul class="navbar-menu">
                     <li class="navbar-item"><a href="' . $this->pathindex . '" class="navbar-link">Accueil</a></li>
-                    <li class="navbar-item"><a href="#" class="navbar-link">Leaderboards</a>
-                    <ul class="sousmenu">
-                        <li class="navbar-item"><a href="' . $this->pathClassementCm . '" class="navbar-link">Classement</a></li>
-                        <li class="navbar-item"><a href="' . $this->pathresultats . '" class="navbar-link">Résultats</a></li>
-                    </ul>
+                    <li class="navbar-item"><a href="' . $this->pathClassementCm . '" class="navbar-link">Classement</a></li>
+                    <li class="navbar-item"><a href="' . $this->pathresultats . '" class="navbar-link">Résultats</a></li>
                     <li class="navbar-item"><a href="' . $this->pathcalendrier . '" class="navbar-link">Calendrier</a></li>
         ';
     }


### PR DESCRIPTION
>>> Nom du développeur
Young-Way
>>> Problème / tâche
Changer l'appellation Leaderboard dans la navbar
>>> Solution
Enlever les sous menus classement et résultat, et les intégrer directement dans la navbar

>>> Note (Facultatif)

┆Issue is synchronized with this [Trello card](https://trello.com/c/ANNnC6Ee) by [Unito](https://www.unito.io)
